### PR TITLE
feature: add support for custom headers

### DIFF
--- a/lib/report-portal-client.js
+++ b/lib/report-portal-client.js
@@ -15,22 +15,22 @@ class RPClient {
      *      endpoint: "http://localhost:8080/api/v1",
      *      launch: "YOUR LAUNCH NAME",
      *      project: "PROJECT NAME",
+     *      (optional) headers: {"X-Custom": "headers"},
      * }
      */
     constructor(params) {
+        const headers = {
+            'User-Agent': 'NodeJS',
+            Authorization: `bearer ${params.token}`,
+            ...(params.headers || {}),
+        };
         this.debug = params.debug;
         this.map = {};
         this.baseURL = [params.endpoint, params.project].join('/');
         this.options = {
-            headers: {
-                'User-Agent': 'NodeJS',
-                Authorization: `bearer ${params.token}`,
-            },
+            headers,
         };
-        this.headers = {
-            'User-Agent': 'NodeJS',
-            Authorization: `bearer ${params.token}`,
-        };
+        this.headers = headers;
         this.token = params.token;
         this.config = params;
         this.helpers = helpers;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reportportal-js-client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
It is not possible to attach custom headers (such as when accessing behind cloudflare).
This adds support for such a use-case.