### PR TITLE
fix: inject custom headers during the getRequestLogWithFile

### DIFF
--- a/lib/report-portal-client.js
+++ b/lib/report-portal-client.js
@@ -540,7 +540,7 @@ class RPClient {
             this.buildMultiPartStream([saveLogRQ], fileObj, MULTIPART_BOUNDARY),
             {
                 headers: {
-                    Authorization: `bearer ${this.token}`,
+                    ...this.headers,
                     'Content-Type': `multipart/form-data; boundary=${MULTIPART_BOUNDARY}`,
                 },
             },


### PR DESCRIPTION
Add missing custom headers in the `getRequestLogWithFile()` section.

Custom headers were introduced by https://github.com/BorisOsipov/reportportal-js-client/pull/13.